### PR TITLE
Adds hook_permission to allow control over sources

### DIFF
--- a/content_hub_extend.module
+++ b/content_hub_extend.module
@@ -88,5 +88,37 @@ function content_hub_extend_access($permission, $entity_type, $entity) {
   $origin = variable_get('content_hub_connector_origin');
 
   $security = new content_hub_extend\Security();
-  return user_access($permission) && $security->accessCheck($entity_type, $entity, $origin);
+
+  if (user_access('access content_hub_extend remote entities')) {
+    return user_access($permission) && $security->accessCheck($entity_type, $entity, $origin);
+  }
+
+  return
+    user_access($permission) &&
+    user_access($security->getEntityPermission($entity_type, $entity)) &&
+    $security->accessCheck($entity_type, $entity, $origin);
+}
+
+/**
+ * Implements hook_permission().
+ */
+function content_hub_extend_permission() {
+  $permissions = array(
+    'access content_hub_extend remote entities' => array(
+      'title' => t('Administer content hub remote entities'),
+      'description' => t('Controls visibility to the source site edit task for entities'),
+    ),
+  );
+
+  if ($sources = content_hub_get_sources()) {
+    foreach ($sources as $source) {
+      $perm = t('access content_hub_extend !source entities', array('!source' => $source['uuid']));
+      $permissions[$perm] = array(
+        'title' => t('Administer content hub entities from !source', array('!source' => $source['name'])),
+        'description' => t('Controls visibility to the source site edit task for entities'),
+      );
+    }
+  }
+
+  return $permissions;
 }

--- a/src/Security.php
+++ b/src/Security.php
@@ -10,6 +10,8 @@ use Drupal\content_hub_connector as content_hub_connector;
 
 class Security {
 
+  const PERMISSION_STRING = 'access content_hub_extend !source entities';
+
   /**
    * Get an entities origin.
    *
@@ -30,6 +32,18 @@ class Security {
   }
 
   /**
+   * Get an origin permission string for an entity.
+   *
+   * @param $entity_type
+   * @param $entity
+   * @return null|string
+   */
+  public function getEntityPermission($entity_type, $entity) {
+    list($entity_id,,) = entity_extract_ids($entity_type, $entity);
+    return t(SELF::PERMISSION_STRING, array('!source' => $this->getEntityOrigin($entity_type, $entity_id)));
+  }
+
+  /**
    * Access check for a given entity.
    *
    * @param $entity_type
@@ -46,7 +60,7 @@ class Security {
     list($entity_id,,) = entity_extract_ids($entity_type, $entity);
     $entity_origin = $this->getEntityOrigin($entity_type, $entity_id);
 
-    return $origin !== $entity_origin;
+    return !empty($entity_origin) && $origin !== $entity_origin;
   }
 
 }


### PR DESCRIPTION
Each source has the ability to be controlled specifically. This will get all available sources from content hub and will create permissions specific to each. When an entity is loaded it will check the source reported for the content hub entity against these permissions.
