### PR TITLE
Fixes issues with entity_uri() causing errors

### DIFF
--- a/content_hub_extend.api.inc.php
+++ b/content_hub_extend.api.inc.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Defines API functions exposed via content_hub_extend.
+ */
+
+/**
+ * Alter the CH source list.
+ *
+ * This allows you to change the name or add arbitrary domains to the contenthub
+ * domain selector tool. The source list will only return domains from your
+ * content network that have indexed content into content hub.
+ *
+ * @param array &$sources
+ *   A list of domains who have indexed content to content hub.
+ */
+function HOOK_content_hub_extend_source_list_alter(&$sources) {
+  // Add an option to the list of available content hub sources.
+  $sources['http://newdomain.com'] = 'name';
+
+  // Provide a customer friendly name for a particular domain.
+  $sources['http://mydomain.com'] = 'new name';
+}

--- a/content_hub_extend.info
+++ b/content_hub_extend.info
@@ -3,5 +3,5 @@ description = Extend functionality provided by Content Hub.
 core = 7.x
 package = Content Hub
 
-dependencies[] = content_hub
+dependencies[] = content_hub_connector
 dependencies[] = iib

--- a/content_hub_extend.module
+++ b/content_hub_extend.module
@@ -21,33 +21,39 @@ function content_hub_extend_init() {
  */
 function content_hub_extend_menu() {
   $items = array();
+
+  // Make sure the classes are available when registering menu items.
   content_hub_extend_init();
-  
-  // Dynamically generate content hub source edit URLs.
+
   module_load_include('inc', 'content_hub_connector', 'content_hub_connector.entityconfig');
 
-  foreach (_content_hub_connector_get_entity_types() as $type => $bundle) {
-    $info = entity_get_info($type);
+  // Dynamically generate content hub source edit URLs.
+  foreach (_content_hub_connector_get_entity_types() as $entity_type => $bundles) {
+    $info = entity_get_info($entity_type);
 
     if ($info['uri callback'] == 'eck__entity__uri' || !is_callable($info['uri callback'])) {
       continue;
     }
 
-    $entity = (object) array(
-      $info['entity keys']['id'] => content_hub_extend\Uri::ENTITY_ID
-    );
+    $entity_values = array($info['entity keys']['id'] => content_hub_extend\Uri::ENTITY_ID);
+
+    if (isset($info['entity keys']['name'])) {
+      $entity_values[$info['entity keys']['name']] = content_hub_extend\Uri::ENTITY_NAME;
+    }
+
+    $entity = entity_create($entity_type, $entity_values);
     $uri = $info['uri callback']($entity);
 
-    $edit_uri = new content_hub_extend\Uri($uri['path'], $type);
-    $edit_uri = $edit_uri->resolve();
+    $edit_uri = new content_hub_extend\Uri($uri['path'], $entity_type);
+    $edit_uri->resolve();
 
-    $items[$edit_uri['path']] = array(
+    $items[$edit_uri->get('path')] = array(
       'title' => 'Edit Source',
       'page callback' => 'content_hub_extend_source_edit',
-      'page arguments' => $edit_uri['args']['page'],
+      'page arguments' => $edit_uri->get('args.page'),
       'access callback' => array('content_hub_extend_access'),
-      'access arguments' => $edit_uri['args']['access'],
-      'load arguments' => $edit_uri['args']['load'],
+      'access arguments' => $edit_uri->get('args.access'),
+      'load arguments' => $edit_uri->get('args.load'),
       'type' => MENU_LOCAL_TASK,
       'weight' => 5,
       'file' => 'content_hub_extend.pages.inc',
@@ -111,14 +117,14 @@ function content_hub_extend_permission() {
     ),
   );
 
-  if ($sources = content_hub_get_sources()) {
-    foreach ($sources as $source) {
-      $perm = t('access content_hub_extend !source entities', array('!source' => $source['uuid']));
-      $permissions[$perm] = array(
-        'title' => t('Administer content hub entities from !source', array('!source' => $source['name'])),
-        'description' => t('Controls visibility to the source site edit task for entities'),
-      );
-    }
+  $sources = content_hub_extend\Source::getAll();
+
+  foreach ($sources as $source) {
+    $perm = t('access content_hub_extend !source entities', array('!source' => $source['uuid']));
+    $permissions[$perm] = array(
+      'title' => t('Administer content hub entities from !source', array('!source' => $source['name'])),
+      'description' => t('Controls visibility to the source site edit task for entities'),
+    );
   }
 
   return $permissions;

--- a/src/Source.php
+++ b/src/Source.php
@@ -7,25 +7,63 @@
 namespace Drupal\content_hub_extend;
 
 use Drupal\content_hub_connector as content_hub_connector;
+use GuzzleHttp\Exception\ServerException;
 
 class Source {
 
   const CACHE_KEY = 'content_hub_extend_source_list';
 
   public static function getAll() {
-    $sources = cache_get(SELF::CACHE_KEY);
+    $sources = cache_get(self::CACHE_KEY);
 
     if (!empty($sources)) {
       return $sources->data;
     }
 
-    $sources = content_hub_get_sources();
+    $client = content_hub_connector_client_load();
+    $sources = array();
+
+    try {
+      $sources = $client->getSettings()->getClients();
+    }
+    catch (ServerException $ex) {
+      $msg = $ex->getMessage();
+      watchdog('content_hub_connector', 'Could not reach the Content Hub [Error message: @msg]', array(
+        '@msg' => $msg,
+      ), WATCHDOG_ERROR);
+    }
+    catch (ConnectException $ex) {
+      $msg = $ex->getMessage();
+      watchdog('content_hub_connector', 'Could not reach the Content Hub. Please verify your hostname URL. [Error message: @msg]', array(
+        '@msg' => $msg,
+      ), WATCHDOG_ERROR);
+    }
+    catch (RequestException $ex) {
+      $msg = $ex->getMessage();
+      watchdog('content_hub_connector', 'Error trying to connect to the Content Hub (Error Message = @error_message)', array(
+        '@error_message' => $msg,
+      ), WATCHDOG_ERROR);
+    }
+    catch (Exception $ex) {
+      $msg = $ex->getMessage();
+      watchdog('content_hub_connector', 'Error trying to connect to the Content Hub (Error Message = @error_message)', array(
+        '@error_message' => $msg,
+      ), WATCHDOG_ERROR);
+    }
+
+    if (empty($sources)) {
+      return $sources;
+    }
 
     foreach ($sources as &$source) {
       $source['domain'] = self::getSourceDomain($source['uuid']);
     }
 
+    // We get unfriendly names from CH so this will allow custom modules to map
+    // CH names => user friendly names.
+    drupal_alter('content_hub_extend_source_list', $sources);
     cache_set(SELF::CACHE_KEY, $sources);
+
     return $sources;
   }
 
@@ -36,7 +74,9 @@ class Source {
    *   Source UUID.
    */
   public static function getSourceDomain($source) {
+    module_load_include('module', 'content_hub');
     module_load_include('inc', 'content_hub', 'content_hub.search');
+
     $results = content_hub_build_search_query($source);
 
     if (empty($results['hits'])) {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -11,6 +11,9 @@ class Uri {
 
   const LOAD_HOOK = '%content_hub_extend';
   const ENTITY_ID = 1;
+  const ENTITY_NAME = 'temp_entity';
+
+  private $data = array();
 
   /**
    * Uri constructor.
@@ -29,7 +32,42 @@ class Uri {
   }
 
   public static function generatePath($path) {
-    return str_replace(self::ENTITY_ID, self::LOAD_HOOK . "/ch", $path);
+    return str_replace(self::searchers(), self::LOAD_HOOK . "/ch", $path);
+  }
+
+  /**
+   * Words that can be present in the entity uri.
+   *
+   * @return array
+   */
+  public static function searchers() {
+    return array(self::ENTITY_ID, self::ENTITY_NAME);
+  }
+
+  /**
+   * Dot notation accessor.
+   *
+   * @param null $path
+   * @param null $default
+   *
+   * @return mixed
+   *   A point in $this->data.
+   */
+  public function get($path = NULL, $default = NULL) {
+    $array = $this->data;
+
+    if (empty($path)) {
+      return $default;
+    }
+
+    $keys = explode('.', $path);
+    foreach ($keys as $key) {
+      if (isset($array[$key])) {
+        $array = $array[$key];
+      }
+    }
+
+    return $array == $this->data ? $default : $array;
   }
 
   /**
@@ -43,13 +81,13 @@ class Uri {
     $key = 0;
 
     foreach ($this->parts as $index => $part) {
-      if ($part == self::ENTITY_ID) {
+      if (in_array($part, self::searchers())) {
         $key = $index;
         break;
       }
     }
 
-    return array(
+    $this->data = array(
       'path' => static::generatePath($this->path),
       'args' => array(
         'page' => array($this->type, $key),
@@ -57,5 +95,7 @@ class Uri {
         'load' => array($this->type, $key),
       ),
     );
+
+    return $this;
   }
 }


### PR DESCRIPTION
Beans uses entity_class_uri as the entity_uri callback, as we were building the entity with a standard object the object does not have the URI method and this would cause the fatal errors.
